### PR TITLE
Pin to docker-compose 1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author='Andy McKay',
     author_email='andym@mozilla.com',
     license='BSD',
-    install_requires=['docker-compose', 'requests==2.5.3'],
+    install_requires=['docker-compose==1.2.0', 'requests==2.5.3'],
     packages=find_packages(),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
All newer versions of docker-compose require requests 2.6 or higher which creates a dependency conflict when you try to run the script (which is a setuptools entry point).

Another way to fix this would be to relax the requests 2.5 requirement.